### PR TITLE
Add new mot 'coach'

### DIFF
--- a/src/Components/RoutingMenu/RoutingMenu.jsx
+++ b/src/Components/RoutingMenu/RoutingMenu.jsx
@@ -37,6 +37,7 @@ import {
   DEFAULT_MOTS,
   OTHER_MOTS,
   GRAPHHOPPER_MOTS,
+  handleStopFinderMot,
 } from '../../constants';
 import { to4326, to3857, findMotIcon } from '../../utils';
 import SearchResults from '../SearchResults';
@@ -411,7 +412,7 @@ function RoutingMenu({
 
     const reqUrl = `${stationSearchUrl}?q=${event.target.value}&key=${APIKey}${
       !GRAPHHOPPER_MOTS.includes(currentMot)
-        ? `&mots=${searchMotOnly ? currentMot : ''}`
+        ? `&mots=${searchMotOnly ? handleStopFinderMot(currentMot) : ''}`
         : ''
     }&ref_location=${to4326(center)
       .reverse()

--- a/src/Components/RoutingMenu/RoutingMenu.jsx
+++ b/src/Components/RoutingMenu/RoutingMenu.jsx
@@ -37,7 +37,6 @@ import {
   DEFAULT_MOTS,
   OTHER_MOTS,
   GRAPHHOPPER_MOTS,
-  handleStopFinderMot,
 } from '../../constants';
 import { to4326, to3857, findMotIcon } from '../../utils';
 import SearchResults from '../SearchResults';
@@ -153,6 +152,9 @@ function RoutingMenu({
     }
     return currentMotsArray;
   };
+
+  // Currently no 'coach' mot available for stop finder.
+  const handleStopFinderMot = mot => (mot === 'coach' ? 'bus' : mot);
 
   const currentMotsVal = validateMots(mots, DEFAULT_MOTS);
   const otherMotsVal = validateMots(mots, OTHER_MOTS);

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,6 +18,3 @@ export const OTHER_MOTS = [
 export const VALID_MOTS = [...DEFAULT_MOTS, ...OTHER_MOTS];
 
 export const GRAPHHOPPER_MOTS = ['foot', 'car'];
-
-// Currently no 'coach' mot available for stop finder.
-export const handleStopFinderMot = mot => (mot === 'coach' ? 'bus' : mot);

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,6 +7,7 @@ export const DEFAULT_MOTS = ['rail', 'bus', 'foot'];
 
 export const OTHER_MOTS = [
   'tram',
+  'coach',
   'subway',
   'gondola',
   'funicular',
@@ -17,3 +18,6 @@ export const OTHER_MOTS = [
 export const VALID_MOTS = [...DEFAULT_MOTS, ...OTHER_MOTS];
 
 export const GRAPHHOPPER_MOTS = ['foot', 'car'];
+
+// Currently no 'coach' mot available for stop finder.
+export const handleStopFinderMot = mot => (mot === 'coach' ? 'bus' : mot);


### PR DESCRIPTION
Add new mot 'coach' to the available ones.
However this mot is not yet present for the stopfinder API, we must use 'bus' in the meantime.

Ticket: TGSRVI-619