### PR TITLE
Disable Menu while loading 

### DIFF
--- a/src/Components/RouteInfosDialog/RouteInfosDialog.jsx
+++ b/src/Components/RouteInfosDialog/RouteInfosDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Feature } from 'ol';
@@ -79,102 +79,113 @@ function RouteInfosDialog({
 
   const dialogPosition = useSelector(state => state.MapReducer.dialogPosition);
 
-  const onDragStop = (evt, position) => {
-    dispatch(
-      setDialogPosition({
-        x: position.lastX,
-        y: position.lastY,
-      }),
-    );
-  };
+  const onDragStop = useCallback(
+    (evt, position) => {
+      dispatch(
+        setDialogPosition({
+          x: position.lastX,
+          y: position.lastY,
+        }),
+      );
+    },
+    [dispatch],
+  );
 
-  const renderPrograTooltip = (hovCoords, linePoints, routeLine) => {
-    const format = new GeoJSON();
+  const renderPrograTooltip = useCallback(
+    (hovCoords, linePoints, routeLine) => {
+      const format = new GeoJSON();
 
-    const line = combine(
-      format.writeFeaturesObject(routeLine, {
+      const line = combine(
+        format.writeFeaturesObject(routeLine, {
+          dataProjection: 'EPSG:4326',
+          featureProjection: 'EPSG:3857',
+        }),
+      ).features[0];
+
+      const hoveredFeat = new Feature({
+        geometry: new Point(hovCoords),
+      });
+      const pt = format.writeFeatureObject(hoveredFeat, {
         dataProjection: 'EPSG:4326',
         featureProjection: 'EPSG:3857',
-      }),
-    ).features[0];
+      });
 
-    const hoveredFeat = new Feature({
-      geometry: new Point(hovCoords),
-    });
-    const pt = format.writeFeatureObject(hoveredFeat, {
-      dataProjection: 'EPSG:4326',
-      featureProjection: 'EPSG:3857',
-    });
+      const turfClosestPt = nearestPointOnLine(line, pt);
+      const lineCoordinates = line.geometry.coordinates;
+      const nearestPts = lineCoordinates.map(coords => {
+        return coords[turfClosestPt.properties.index];
+      });
+      const nearestPt = nearestPts.reduce((prev, curr) => {
+        const goal = turfClosestPt.geometry.coordinates[0];
+        if (!prev) {
+          return curr;
+        }
+        return curr &&
+          prev &&
+          Math.abs(curr[0] - goal) < Math.abs(prev[0] - goal)
+          ? curr
+          : prev;
+      });
 
-    const turfClosestPt = nearestPointOnLine(line, pt);
-    const lineCoordinates = line.geometry.coordinates;
-    const nearestPts = lineCoordinates.map(coords => {
-      return coords[turfClosestPt.properties.index];
-    });
-    const nearestPt = nearestPts.reduce((prev, curr) => {
-      const goal = turfClosestPt.geometry.coordinates[0];
-      if (!prev) {
-        return curr;
+      const hoveredLineIdx = nearestPts.indexOf(nearestPt);
+      // Turf only return the index within the closest feature.
+      // We need to add the length of each preceding feature to have the correct index.
+      let nearestPtIndex = turfClosestPt.properties.index;
+      for (let i = 0; i < hoveredLineIdx; i += 1) {
+        nearestPtIndex += lineCoordinates[i].length;
       }
-      return curr && prev && Math.abs(curr[0] - goal) < Math.abs(prev[0] - goal)
-        ? curr
-        : prev;
-    });
 
-    const hoveredLineIdx = nearestPts.indexOf(nearestPt);
-    // Turf only return the index within the closest feature.
-    // We need to add the length of each preceding feature to have the correct index.
-    let nearestPtIndex = turfClosestPt.properties.index;
-    for (let i = 0; i < hoveredLineIdx; i += 1) {
-      nearestPtIndex += lineCoordinates[i].length;
-    }
+      const point = linePoints[nearestPtIndex];
+      setHoveredPoint(point);
 
-    const point = linePoints[nearestPtIndex];
-    setHoveredPoint(point);
-
-    if (!point) {
-      return null;
-    }
-    return (
-      <div className="rd-tootip-wrapper">
-        <div>surface elevation: {point.surfaceElevation} m</div>
-        <div>interpolated altitude: {point.alt} m</div>
-        <div>
-          distance: {tickFormatter(point.distance, isMeter)}
-          {isMeter ? ' m' : ' km'}
+      if (!point) {
+        return null;
+      }
+      return (
+        <div className="rd-tootip-wrapper">
+          <div>surface elevation: {point.surfaceElevation} m</div>
+          <div>interpolated altitude: {point.alt} m</div>
+          <div>
+            distance: {tickFormatter(point.distance, isMeter)}
+            {isMeter ? ' m' : ' km'}
+          </div>
         </div>
-      </div>
-    );
-  };
+      );
+    },
+    [isMeter],
+  );
 
-  const renderTooltip = tooltipProps => {
-    if (hoveredPoint) {
-      setHoveredPoint(null);
-    }
-    if (!tooltipProps.payload.length) {
-      return;
-    }
-    const {
-      xVal,
-      yVal,
-      alt,
-      surfaceElevation,
-      distance,
-    } = tooltipProps.payload[0].payload;
+  const renderTooltip = useCallback(
+    tooltipProps => {
+      if (hoveredPoint) {
+        setHoveredPoint(null);
+      }
+      if (!tooltipProps.payload.length) {
+        return;
+      }
+      const {
+        xVal,
+        yVal,
+        alt,
+        surfaceElevation,
+        distance,
+      } = tooltipProps.payload[0].payload;
 
-    onHighlightPoint([xVal, yVal]);
-    // eslint-disable-next-line consistent-return
-    return (
-      <div className="rd-tootip-wrapper">
-        <div>surface elevation: {surfaceElevation} m</div>
-        <div>interpolated altitude: {alt} m</div>
-        <div>
-          distance: {tickFormatter(distance, isMeter)}
-          {isMeter ? ' m' : ' km'}
+      onHighlightPoint([xVal, yVal]);
+      // eslint-disable-next-line consistent-return
+      return (
+        <div className="rd-tootip-wrapper">
+          <div>surface elevation: {surfaceElevation} m</div>
+          <div>interpolated altitude: {alt} m</div>
+          <div>
+            distance: {tickFormatter(distance, isMeter)}
+            {isMeter ? ' m' : ' km'}
+          </div>
         </div>
-      </div>
-    );
-  };
+      );
+    },
+    [hoveredPoint, isMeter, onHighlightPoint],
+  );
 
   useEffect(() => {
     const pointArray = [];

--- a/src/Components/RoutingMenu/RoutingMenu.jsx
+++ b/src/Components/RoutingMenu/RoutingMenu.jsx
@@ -598,6 +598,9 @@ function RoutingMenu({
   return (
     <div className="rd-routing-menu">
       <Paper square elevation={3}>
+        <div style={{ height: 5 }}>
+          {showLoadingBar ? <LinearProgress /> : null}
+        </div>
         <div className="rd-routing-menu-header">
           <Tabs
             value={DEFAULT_MOTS.includes(currentMot) ? currentMot : false}
@@ -617,6 +620,7 @@ function RoutingMenu({
                   value={singleMot.name}
                   icon={singleMot.icon}
                   aria-label={singleMot.name}
+                  disabled={showLoadingBar}
                 />
               );
             })}
@@ -631,6 +635,7 @@ function RoutingMenu({
               disableUnderline={!currentOtherMot}
               displayEmpty
               onChange={changeCurrentOtherMot}
+              disabled={showLoadingBar}
             >
               {otherMots.map(mot => {
                 return (
@@ -758,7 +763,6 @@ function RoutingMenu({
             </Grid>
           </div>
         </TabPanel>
-        {showLoadingBar ? <LinearProgress /> : null}
       </Paper>
       <SearchResults
         currentSearchResults={currentSearchResults}

--- a/src/Components/SearchField/SearchField.jsx
+++ b/src/Components/SearchField/SearchField.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { makeStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import Grid from '@material-ui/core/Grid';
@@ -52,6 +52,7 @@ const useStyles = makeStyles(theme => ({
 function SearchField(props) {
   const classes = useStyles();
   const dispatch = useDispatch();
+  const showLoadingBar = useSelector(state => state.MapReducer.showLoadingBar);
   const {
     index,
     addNewSearchFieldHandler,
@@ -98,7 +99,7 @@ function SearchField(props) {
         <Tooltip title="Add Hop">
           <IconButton
             onClick={() => addNewSearchFieldHandler(currentStops, index + 1)}
-            disabled={addNextHopDisabled}
+            disabled={addNextHopDisabled || showLoadingBar}
             className={classes.button}
             aria-label="Add Hop"
             size="small"
@@ -142,7 +143,7 @@ function SearchField(props) {
         <Grid item xs={1} className={classes.buttonWrapper}>
           <Tooltip title="Add Hop">
             <IconButton
-              disabled={addNextHopDisabled}
+              disabled={addNextHopDisabled || showLoadingBar}
               onClick={() => addNewSearchFieldHandler(currentStops, index + 1)}
               className={classes.button}
               aria-label="addHop"
@@ -159,6 +160,7 @@ function SearchField(props) {
               className={classes.button}
               aria-label="removeHop"
               size="small"
+              disabled={showLoadingBar}
             >
               <RemoveCircleOutlineIcon fontSize="small" />
             </IconButton>

--- a/src/store/reducers/Map.jsx
+++ b/src/store/reducers/Map.jsx
@@ -15,7 +15,7 @@ const initialState = {
   isRouteInfoOpen: false,
   dialogPosition: {
     x: 10,
-    y: 275,
+    y: 280,
   },
   olMap: new Map({
     controls: [],


### PR DESCRIPTION
**Issue**: While the RouteInfoDialog is calculating the route profile an MOT switch causes the app to crash

**Fix**: The menu header items have been disabled while routes and profiles to prevent crashes

**Other updates**: 
- The Loading bar has been moved to the top of the menu, since it was sometimes obscured by the RouteInfoDialog
- Using useCallback in RouteInfoDialog functions to boost performance
- RouteInfoDialog starting position slightly adjusted