### PR TITLE
Gevos/floor switcher fix

### DIFF
--- a/src/Components/FloorSwitcher/FloorSwitcher.jsx
+++ b/src/Components/FloorSwitcher/FloorSwitcher.jsx
@@ -5,6 +5,7 @@ import Button from '@geops/react-ui/components/Button';
 import { FiArrowUp, FiArrowDown } from 'react-icons/fi';
 import { getBottomLeft, getTopRight } from 'ol/extent';
 import { to4326 } from '../../utils';
+import { FLOOR_LEVELS } from '../../constants';
 
 import { propTypeCoordinates } from '../../store/prop-types';
 import { setActiveFloor, showNotification } from '../../store/actions/Map';
@@ -88,7 +89,10 @@ class FloorSwitcher extends PureComponent {
         if (!response.properties.availableLevels) {
           dispatchShowNotification("Couldn't find available levels", 'warning');
         }
-        const floors = response.properties.availableLevels.join().split(',');
+        const floors = response.properties.availableLevels
+          .filter(level => FLOOR_LEVELS.includes(level))
+          .join()
+          .split(',');
         if (!floors.includes('2D')) {
           floors.splice(floors.indexOf('0') + 1, 0, '2D');
         }

--- a/src/Components/MapComponent/MapComponent.jsx
+++ b/src/Components/MapComponent/MapComponent.jsx
@@ -111,7 +111,7 @@ class MapComponent extends PureComponent {
       visible: true,
     });
 
-    geschosseLayer.children = [-4, -3, -2, -1, -0.5, 0, '2D', 1, 2, 3, 4].map(
+    geschosseLayer.children = [-4, -3, -2, -1, 0, '2D', 1, 2, 3, 4].map(
       level => {
         return new LevelLayer({
           name: `ch.sbb.geschosse${level}`,

--- a/src/Components/MapComponent/MapComponent.jsx
+++ b/src/Components/MapComponent/MapComponent.jsx
@@ -30,6 +30,7 @@ import {
   propTypeCurrentStopsGeoJSON,
 } from '../../store/prop-types';
 import { to4326 } from '../../utils';
+import { FLOOR_LEVELS } from '../../constants';
 import './MapComponent.scss';
 import * as actions from '../../store/actions';
 
@@ -111,21 +112,19 @@ class MapComponent extends PureComponent {
       visible: true,
     });
 
-    geschosseLayer.children = [-4, -3, -2, -1, 0, '2D', 1, 2, 3, 4].map(
-      level => {
-        return new LevelLayer({
-          name: `ch.sbb.geschosse${level}`,
-          visible: level === activeFloor,
-          mapboxLayer: dataLayer,
-          styleLayersFilter: ({ metadata }) =>
-            metadata && metadata['geops.filter'],
-          level,
-          properties: {
-            radioGroup: 'ch.sbb.geschosse-layer',
-          },
-        });
-      },
-    );
+    geschosseLayer.children = FLOOR_LEVELS.map(level => {
+      return new LevelLayer({
+        name: `ch.sbb.geschosse${level}`,
+        visible: level === activeFloor,
+        mapboxLayer: dataLayer,
+        styleLayersFilter: ({ metadata }) =>
+          metadata && metadata['geops.filter'],
+        level,
+        properties: {
+          radioGroup: 'ch.sbb.geschosse-layer',
+        },
+      });
+    });
     layerService.addLayer(geschosseLayer);
 
     // Define route vectorLayer.

--- a/src/config/styleConfig.js
+++ b/src/config/styleConfig.js
@@ -3,7 +3,7 @@ import { Style, Circle, Stroke, Fill } from 'ol/style';
 
 // Convert '0.0' to '0'
 const cleanFloor = floor => {
-  return !isNaN(floor) ? parseInt(floor, 10).toString() : floor;
+  return !isNaN(floor) ? parseFloat(floor, 10).toString() : floor;
 };
 
 const lineStyler = lineStyle => {

--- a/src/config/styleConfig.js
+++ b/src/config/styleConfig.js
@@ -88,7 +88,7 @@ const pedestrianGeopsPointStyle = (floor, activeFloor) => {
   return new Style({
     image: new Circle({
       radius: 8,
-      fill: new Fill({ color: floorColor }),
+      fill: new Fill({ color: floorColor || 'black' }),
     }),
   });
 };
@@ -132,7 +132,7 @@ const lineStyleFunction = (mot, isHovered, floor, activeFloor) => {
   if (mot === 'foot') {
     const f = cleanFloor(floor);
     const floorColor = f === activeFloor ? floorsColor[f] : floorsColorGrey[f];
-    const stroke = floorColor && floorColor.length ? floorColor : 'blue';
+    const stroke = floorColor && floorColor.length ? floorColor : 'black';
     return lineStyler([[stroke, 7, [1, 10]]]);
   }
   return isHovered ? othersLineHoveredStyle : othersLineStyle;

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,6 +18,8 @@ export const VALID_MOTS = [...DEFAULT_MOTS, ...OTHER_MOTS];
 
 export const SEARCH_MODES = ['default', 'barrier-free'];
 
+export const FLOOR_LEVELS = [-4, -3, -2, -1, 0, '2D', 1, 2, 3, 4];
+
 export const ROUTING_BASE_URL = 'https://api.geops.io/routing/';
 
 export const STATION_SEARCH_BASE_URL = 'https://api.geops.io/stops/';


### PR DESCRIPTION
FloorSwitcher: Only allow floor levels [-4, -3, -2, -1, 0, '2D', 1, 2, 3, 4], but allow all floor levels in FloorSelect (for a stop):

- Go to https://deploy-preview-40--geops-routing-demo.netlify.app/?floorInfo=-0.5,0&mot=foot&resolve-hops=false&via=7.83794,47.99719%7C7.83785,47.99713&x=872511.19&y=6106380.55&z=22.32 (next to Freiburg Hbf)
=> The floor level layer -0.5 is not shown in the FloorSwitcher
But the floor level -0.5 is available for the first stop
- Switch the floor levels at the FloorSwitcher
=> The first point and the line next to it should always be black (= default color if floor level is not part of [-4, -3, -2, -1, 0, 1, 2, 3, 4])

