### PR TITLE
Use single blue tone in foot routing 2D mode

### DIFF
--- a/src/config/styleConfig.js
+++ b/src/config/styleConfig.js
@@ -85,7 +85,7 @@ const getPedestrianStyleColor = (floor, activeFloor) => {
   const f = cleanFloor(floor);
   let floorColor = f === activeFloor ? floorsColor[f] : floorsColorGrey[f];
   if (activeFloor === '2D') {
-    floorColor = floorsColor[f];
+    floorColor = floorsColor['0'];
   }
   return floorColor || 'black';
 };

--- a/src/config/styleConfig.js
+++ b/src/config/styleConfig.js
@@ -81,14 +81,22 @@ const floorsColorGrey = {
   '4': '#222222',
 };
 
-const pedestrianGeopsPointStyle = (floor, activeFloor) => {
+const getPedestrianStyleColor = (floor, activeFloor) => {
   const f = cleanFloor(floor);
-  const floorColor = f === activeFloor ? floorsColor[f] : floorsColorGrey[f];
+  let floorColor = f === activeFloor ? floorsColor[f] : floorsColorGrey[f];
+  if (activeFloor === '2D') {
+    floorColor = floorsColor[f];
+  }
+  return floorColor || 'black';
+};
 
+const pedestrianGeopsPointStyle = (floor, activeFloor) => {
   return new Style({
     image: new Circle({
       radius: 8,
-      fill: new Fill({ color: floorColor || 'black' }),
+      fill: new Fill({
+        color: getPedestrianStyleColor(floor, activeFloor),
+      }),
     }),
   });
 };
@@ -130,10 +138,8 @@ const lineStyleFunction = (mot, isHovered, floor, activeFloor) => {
     return isHovered ? busLineHoveredStyle : busLineStyle;
   }
   if (mot === 'foot') {
-    const f = cleanFloor(floor);
-    const floorColor = f === activeFloor ? floorsColor[f] : floorsColorGrey[f];
-    const stroke = floorColor && floorColor.length ? floorColor : 'black';
-    return lineStyler([[stroke, 7, [1, 10]]]);
+    const floorColor = getPedestrianStyleColor(floor, activeFloor);
+    return lineStyler([[floorColor, 7, [1, 10]]]);
   }
   return isHovered ? othersLineHoveredStyle : othersLineStyle;
 };


### PR DESCRIPTION
Since the gray pedestrian styles do not contrast enough with the basemap we use a single blue tone in standard 2D mode and only differentiate floors by colors when a floor is explicitly selected.