### PR TITLE
Reverse FloorSwitcher floor order

### DIFF
--- a/src/Components/FloorSelect/FloorSelect.jsx
+++ b/src/Components/FloorSelect/FloorSelect.jsx
@@ -134,7 +134,7 @@ function FloorSelect({ index, disabled, singleStop }) {
           dispatch(setFloorInfo(newFloorInfo));
         }}
       >
-        {floors.map(fl => {
+        {floors.reverse().map(fl => {
           return (
             <MenuItem value={fl} key={`floor-${fl}`}>
               {fl === '' ? '0' : fl}

--- a/src/Components/FloorSwitcher/FloorSwitcher.jsx
+++ b/src/Components/FloorSwitcher/FloorSwitcher.jsx
@@ -96,7 +96,7 @@ class FloorSwitcher extends PureComponent {
           floors.splice(floors.indexOf('0') + 1, 0, '2D');
         }
         this.setState({
-          floors,
+          floors: floors.reverse(),
         });
       })
       .catch(err => {


### PR DESCRIPTION
The floors in the foot routing FloorSwitcher currently show the negative (underground) floors on top, though they should be at the bottom.

Fix: The floor order was reversed