### PR TITLE
fix(foot routing: refactor hop index finding for foot routing

### DIFF
--- a/src/utils/projection.js
+++ b/src/utils/projection.js
@@ -2,7 +2,7 @@ import { transform } from 'ol/proj';
 
 export const to4326 = (coord, decimal = 5) => {
   return transform(coord, 'EPSG:3857', 'EPSG:4326').map((c) =>
-    c.toFixed(decimal),
+    parseFloat(c.toFixed(decimal)),
   );
 };
 


### PR DESCRIPTION
Due to changes in the foot routing request responses the segmentation while drag-modifying the route stopped working and the finding the hop index resulted in an error and broke the app.

A separate more robust approach now gets the correct hop for foot routing.

Test: draw a foot route and modify the route by dragging now hops into the route.